### PR TITLE
Restore PHP 5.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3
   - 5.4
   - 5.5
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "chunks"
   ],
   "require": {
-      "php": ">=5.4"
+      "php": ">=5.3"
   },
   "require-dev": {
     "mikey179/vfsStream": "v1.2.0",

--- a/test/Unit/ConfigTest.php
+++ b/test/Unit/ConfigTest.php
@@ -24,12 +24,12 @@ class ConfigTest extends FlowUnitCase
 	 */
 	public function testConfig_construct_config()
 	{
-		$exampleConfig = [
+		$exampleConfig = array(
 			'tempDir' => '/some/dir',
 		    'deleteChunksOnSave' => TRUE,
 		    'hashNameCallback' => '\SomeNs\SomeClass::someMethod',
 		    'preprocessCallback' => '\SomeNs\SomeClass::preProcess'
-		];
+		);
 
 		$config = new Config($exampleConfig);
 

--- a/test/Unit/FileTest.php
+++ b/test/Unit/FileTest.php
@@ -124,27 +124,27 @@ class FileTest extends FlowUnitCase
 		$this->assertFalse($file->validateChunk());
 
 		// Upload OK
-		$fileInfo->exchangeArray([
+		$fileInfo->exchangeArray(array(
 			'size' => 10,
 			'error' => UPLOAD_ERR_OK,
 			'tmp_name' => ''
-		]);
+		));
 		$this->assertTrue($file->validateChunk());
 
 		// Chunk size doesn't match
-		$fileInfo->exchangeArray([
+		$fileInfo->exchangeArray(array(
 			'size' => 9,
 			'error' => UPLOAD_ERR_OK,
 			'tmp_name' => ''
-		]);
+		));
 		$this->assertFalse($file->validateChunk());
 
 		// Upload error
-		$fileInfo->exchangeArray([
+		$fileInfo->exchangeArray(array(
 			'size' => 10,
 			'error' => UPLOAD_ERR_EXTENSION,
 			'tmp_name' => ''
-		]);
+		));
 		$this->assertFalse($file->validateChunk());
 	}
 
@@ -250,7 +250,7 @@ class FileTest extends FlowUnitCase
 
 		// Mock File to use rename instead of move_uploaded_file
 		$request = new Request($this->requestArr, $this->filesArr['file']);
-		$file = $this->getMock('Flow\File', ['_move_uploaded_file'], [$this->config, $request]);
+		$file = $this->getMock('Flow\File', array('_move_uploaded_file'), array($this->config, $request));
 		$file->expects($this->once())
 		     ->method('_move_uploaded_file')
 		     ->will($this->returnCallback(function ($filename, $destination) {

--- a/test/Unit/FlowUnitCase.php
+++ b/test/Unit/FlowUnitCase.php
@@ -23,7 +23,7 @@ class FlowUnitCase extends \PHPUnit_Framework_TestCase
 
 	protected function setUp()
 	{
-		$this->requestArr = new ArrayObject([
+		$this->requestArr = new ArrayObject(array(
 			'flowChunkNumber' => 1,
 			'flowChunkSize' => 1048576,
 			'flowCurrentChunkSize' => 10,
@@ -32,22 +32,22 @@ class FlowUnitCase extends \PHPUnit_Framework_TestCase
 			'flowFilename' => 'prettify.js',
 			'flowRelativePath' => 'home/prettify.js',
 			'flowTotalChunks' => 42
-		]);
+		));
 
-		$this->filesArr = [
-			'file' => [
+		$this->filesArr = array(
+			'file' => array(
 				'name' => 'someFile.gif',
 				'type' => 'image/gif',
 				'size' => '10',
 				'tmp_name' => '/tmp/abc1234',
 				'error' => UPLOAD_ERR_OK
-			]
-		];
+			)
+		);
 	}
 
 	protected function tearDown()
 	{
-		$_REQUEST = [];
-		$_FILES = [];
+		$_REQUEST = array();
+		$_FILES = array();
 	}
 }

--- a/test/Unit/FustyRequestTest.php
+++ b/test/Unit/FustyRequestTest.php
@@ -45,17 +45,17 @@ class FustyRequestTest extends FlowUnitCase
 	    $firstChunk->setContent('1234567890');
 	    $this->vfs->addChild($firstChunk);
 
-	    $fileInfo = new \ArrayObject([
+	    $fileInfo = new \ArrayObject(array(
 		    'size' => 10,
 		    'error' => UPLOAD_ERR_OK,
 		    'tmp_name' => $firstChunk->url()
-	    ]);
+	    ));
 
-	    $request =  new \ArrayObject([
+	    $request =  new \ArrayObject(array(
 		    'flowIdentifier' => '13632-prettifyjs',
 		    'flowFilename' => 'prettify.js',
 		    'flowRelativePath' => 'home/prettify.js'
-	    ]);
+	    ));
 
 	    $fustyRequest = new FustyRequest($request, $fileInfo);
 
@@ -80,17 +80,17 @@ class FustyRequestTest extends FlowUnitCase
 		$firstChunk->setContent('1234567890');
 		$this->vfs->addChild($firstChunk);
 
-		$fileInfo = new \ArrayObject([
+		$fileInfo = new \ArrayObject(array(
 			'size' => 10,
 			'error' => UPLOAD_ERR_OK,
 			'tmp_name' => $firstChunk->url()
-		]);
+		));
 
-		$request =  new \ArrayObject([
+		$request =  new \ArrayObject(array(
 			'flowIdentifier' => '13632-prettifyjs',
 			'flowFilename' => 'prettify.js',
 			'flowRelativePath' => 'home/prettify.js'
-		]);
+		));
 
 		$fustyRequest = new FustyRequest($request, $fileInfo);
 
@@ -98,7 +98,7 @@ class FustyRequestTest extends FlowUnitCase
 		$config->setTempDir($this->vfs->url());
 
 		/** @var File $file */
-		$file = $this->getMock('Flow\File', array('_move_uploaded_file'), [$config, $fustyRequest]);
+		$file = $this->getMock('Flow\File', array('_move_uploaded_file'), array($config, $fustyRequest));
 
 		/** @noinspection PhpUndefinedMethodInspection */
 		$file->expects($this->once())


### PR DESCRIPTION
The package is compatible with PHP 5.3 apart from the array notation. I think it's better to take a conservative approach and keep the backward compatibility.

Redoing this because of scrutinizer failing the first time.