### PR TITLE
To pass custom data in query parameter

### DIFF
--- a/src/Flow/Request.php
+++ b/src/Flow/Request.php
@@ -45,7 +45,7 @@ class Request implements RequestInterface
      *
      * @return string|int|null
      */
-    protected function getParam($name)
+    public function getParam($name)
     {
         return isset($this->params[$name]) ? $this->params[$name] : null;
     }


### PR DESCRIPTION
There is a query option in flow.js object, and it sends it's contents to php in params member of the Request object. BUT! it is not accessible in client code. This PR makes it possible to access custom params specified in client part in the query option.