### PR TITLE
Feature/check chunk number

### DIFF
--- a/src/Flow/File.php
+++ b/src/Flow/File.php
@@ -119,6 +119,11 @@ class File
     public function validateFile()
     {
         $totalChunks = $this->request->getTotalChunks();
+        $chunkNumber = $this->request->getCurrentChunkNumber();
+        if ($chunkNumber != $totalChunks) {
+            return false;
+        }
+
         $totalChunksSize = 0;
 
         for ($i = 1; $i <= $totalChunks; $i++) {

--- a/test/Unit/FileTest.php
+++ b/test/Unit/FileTest.php
@@ -155,6 +155,7 @@ class FileTest extends FlowUnitCase
 	{
 		$this->requestArr['flowTotalSize'] = 10;
 		$this->requestArr['flowTotalChunks'] = 3;
+		$this->requestArr['flowChunkNumber'] = 3;
 
 		$request = new Request($this->requestArr);
 		$file = new File($this->config, $request);


### PR DESCRIPTION
For some occasion, I have seen `$file->validateFile()` passes at second last request of POST.
I think it would be good to check explicitly if current chunk number is the last one.