### PR TITLE
Change the chunk check order for speeding

### DIFF
--- a/src/Flow/File.php
+++ b/src/Flow/File.php
@@ -121,7 +121,7 @@ class File
         $totalChunks = $this->request->getTotalChunks();
         $totalChunksSize = 0;
 
-        for ($i = 1; $i <= $totalChunks; $i++) {
+        for ($i = $totalChunks; $i >= 1; $i--) {
             $file = $this->getChunkPath($i);
             if (!file_exists($file)) {
                 return false;


### PR DESCRIPTION
When we upload big files, uploading speed gets slower and slower.
By changing the checking order, we can upload files faster.
