### PR TITLE
Flexible length for the chunk "sub identifier"

### DIFF
--- a/src/Flow/File.php
+++ b/src/Flow/File.php
@@ -22,6 +22,13 @@ class File
     private $identifier;
 
     /**
+     * Minimum number of digits for the chunk sub identifier.
+     *
+     * @var int
+     */
+    private $pad_length = 0;
+
+    /**
      * Constructor
      *
      * @param ConfigInterface  $config
@@ -53,11 +60,18 @@ class File
      * Return chunk path
      *
      * @param int $index
+     * @param int $pad_length
      *
      * @return string
      */
-    public function getChunkPath($index)
+    public function getChunkPath($index, $pad_length = -1)
     {
+        if($pad_length == -1){
+            $pad_length = $this->pad_length;
+        }
+        if($pad_length > 0){
+            $index = str_pad($index, $pad_length, '0', STR_PAD_LEFT);
+        }
         return $this->config->getTempDir().DIRECTORY_SEPARATOR.$this->identifier.'_'.$index;
     }
 


### PR DESCRIPTION
Hi,

Thank you for this great tool!

I prefer to re-assemble the file using system tools (like `cat chunk_* > complete_file`), but the ordering is wrong because `chunk_10` is sorted before `chunk_2`. I would like the "sub-identifier" to be padded : `chunk_02`.

---

This PR proposes a new parameter: `$pad_length`.

Using this parameter, one can choose a minimum length of the "sub-identifier". I also added an optional parameter to `getChunkPath`, because I intend to call `getChunkPath('*', 0)` to get the file pattern for my `cat` command.

I need your help to determine the best way to set the "global" `$pad_length`: should I use the `ConfigInterface` and add a parameter there ?
