### PR TITLE
Edited upload.php example in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ require_once './vendor/autoload.php';
 $config = new \Flow\Config();
 $config->setTempDir('./chunks_temp_folder');
 $request = new \Flow\Request();
-if (\Flow\Basic::save('./' . $request->getIdentifier(), $config, $request)) {
-  // file saved successfully and can be accessed at './final_file_destination'
+$uploadFolder = './final_file_destination/' // Folder where the file will be stored
+$uploadFileName = uniqid()."_".$request->getFileName(); // The name the file will have on the server
+$uploadPath = $uploadFolder.$uploadFileName;
+if (\Flow\Basic::save($uploadPath, $config, $request)) {
+  // file saved successfully and can be accessed at $uploadPath
 } else {
   // This is not a final chunk or request is invalid, continue to upload.
 }


### PR DESCRIPTION
I changed the example for the `upload.php` file because in my opinion could be confusing: it uses the `getIdentifier()` method to give a name to the uploaded file, which produces a file without an extension and which is not intended for naming files, as suggested to me [here](https://github.com/flowjs/flow.js/pull/192#issuecomment-250527221).